### PR TITLE
pin tailwind v3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,8 @@ gem "turbo-rails"
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem "stimulus-rails"
 # Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]
-gem "tailwindcss-rails"
+# https://github.com/rails/tailwindcss-rails?tab=readme-ov-file#you-dont-have-to-upgrade
+gem "tailwindcss-rails", "~> 3.3.1" # which transitively pins tailwindcss-ruby to v3
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -521,7 +521,7 @@ DEPENDENCIES
   solid_cache
   solid_queue
   stimulus-rails
-  tailwindcss-rails
+  tailwindcss-rails (~> 3.3.1)
   thruster
   turbo-rails
   tzinfo-data


### PR DESCRIPTION
Pinning to v3 because upgrade path with Rails 8 (no JS tooling) is kind of a mess right now, see comment: https://github.com/danielabar/hello-visitor/pull/73#issuecomment-2708507259