### PR TITLE
Add Day/Month granularity toggle to the dashboard

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,6 +14,12 @@ FactoryBot/ExcessiveCreateList:
     - 'spec/models/visit_spec.rb'
 
 # Offense count: 1
+# Configuration parameters: CountComments, Max, CountAsOne, AllowedMethods, AllowedPatterns.
+Metrics/ClassLength:
+  Exclude:
+    - 'app/queries/visit_query.rb'
+
+# Offense count: 1
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
   Max: 18

--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -43,7 +43,7 @@ class VisitsController < ApplicationController
   end
 
   def visit_search_params
-    params.expect(visit_search: %i[url referrer start_date end_date])
+    params.expect(visit_search: %i[url referrer start_date end_date granularity])
   end
 
   # https://stackoverflow.com/questions/3985989/using-sanitize-within-a-rails-controller

--- a/app/helpers/visits_helper.rb
+++ b/app/helpers/visits_helper.rb
@@ -1,6 +1,27 @@
 # frozen_string_literal: true
 
 module VisitsHelper
+  def granularity_link(label, value, visit_search)
+    is_active = visit_search.granularity == value
+    search_params = {
+      granularity: value,
+      start_date: visit_search.start_date,
+      end_date: visit_search.end_date,
+      url: visit_search.url,
+      referrer: visit_search.referrer
+    }
+    path = visits_path(visit_search: search_params)
+
+    if is_active
+      content_tag(:span, label,
+                  class: "px-4 py-2 bg-indigo-100 text-indigo-600 font-medium cursor-not-allowed",
+                  data: { test_id: "granularity-active", label: label })
+    else
+      link_to(label, path, class: "px-4 py-2 text-indigo-500 hover:bg-gray-100 focus:outline-none",
+                           data: { test_id: "granularity-link", label: label })
+    end
+  end
+
   def quick_filter_link(label, range, current_range, path)
     is_active = range[:start_date] == current_range[:start_date] && range[:end_date] == current_range[:end_date]
     if is_active

--- a/app/models/stats.rb
+++ b/app/models/stats.rb
@@ -1,23 +1,25 @@
 # frozen_string_literal: true
 
 class Stats
-  attr_reader :visits, :summary, :by_page, :by_page_bottom, :by_referrer, :by_date, :raw_data
+  attr_reader :visits, :summary, :by_page, :by_page_bottom, :by_referrer, :by_date, :by_month, :raw_data
 
   def initialize(visit_search)
     @visit_search = visit_search
   end
 
   def collect
-    @visits = Visit.limit(100).order(created_at: :desc)
-    @summary = Visit.summary(@visit_search)
-    @by_page = Visit.by_page(@visit_search)
+    @visits         = Visit.limit(100).order(created_at: :desc)
+    @summary        = @visit_search.monthly? ? Visit.monthly_summary(@visit_search) : Visit.summary(@visit_search)
+    @by_page        = Visit.by_page(@visit_search)
     @by_page_bottom = Visit.by_page_bottom(@visit_search)
-    @by_referrer = Visit.by_referrer(@visit_search)
-    @by_date = Visit.by_date(@visit_search)
+    @by_referrer    = Visit.by_referrer(@visit_search)
+    @by_month       = Visit.by_month(@visit_search) if @visit_search.monthly?
+    @by_date        = Visit.by_date(@visit_search) unless @visit_search.monthly?
     @raw_data = { summary: @summary,
                   by_page: @by_page,
                   by_page_bottom: @by_page_bottom,
                   by_date: @by_date,
+                  by_month: @by_month,
                   by_referrer: @by_referrer,
                   visits: @visits }
   end

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -38,4 +38,19 @@ class Visit < ApplicationRecord
   def self.by_date(visit_search)
     VisitQuery.by_date(visit_search).map { |v| [v["visit_date"].strftime("%Y-%m-%d"), v["visit_count"]] }
   end
+
+  def self.by_month(visit_search)
+    VisitQuery.by_month(visit_search).map { |v| [v["visit_month"].strftime("%Y-%m-%d"), v["visit_count"]] }
+  end
+
+  def self.monthly_summary(visit_search)
+    result = VisitQuery.monthly_summary(visit_search)
+    {
+      avg_monthly_visits: result[0]["avg_monthly_visits"],
+      total_visits: result[0]["total_visits"],
+      median_monthly_visits: result[0]["median_monthly_visits"],
+      min_visits: result[0]["min_visits"],
+      max_visits: result[0]["max_visits"]
+    }
+  end
 end

--- a/app/models/visit_search.rb
+++ b/app/models/visit_search.rb
@@ -10,6 +10,11 @@ class VisitSearch
   attribute :referrer, :string, default: -> { "" }
   attribute :start_date, :date, default: -> { 1.month.ago.to_date }
   attribute :end_date, :date, default: -> { Time.zone.today }
+  attribute :granularity, :string, default: "day"
+
+  def monthly?
+    granularity == "month"
+  end
 
   def start_datetime
     start_date&.beginning_of_day

--- a/app/queries/visit_query.rb
+++ b/app/queries/visit_query.rb
@@ -92,4 +92,42 @@ class VisitQuery
     Visit.find_by_sql([sql, visit_search.start_datetime, visit_search.end_datetime, "%#{visit_search.url}%",
                        "%#{visit_search.referrer}%"])
   end
+
+  def self.by_month(visit_search)
+    sql = <<~SQL.squish
+      SELECT DATE_TRUNC('month', created_at) AS visit_month
+           , COUNT(*) AS visit_count
+      FROM visits
+      WHERE created_at >= ?
+        AND created_at <= ?
+        AND url LIKE ?
+        AND COALESCE(referrer, '') ILIKE ?
+      GROUP BY DATE_TRUNC('month', created_at)
+      ORDER BY DATE_TRUNC('month', created_at)
+    SQL
+    Visit.find_by_sql([sql, visit_search.start_datetime, visit_search.end_datetime,
+                       "%#{visit_search.url}%", "%#{visit_search.referrer}%"])
+  end
+
+  def self.monthly_summary(visit_search)
+    sql = <<~SQL.squish
+      SELECT avg(visit_count)::numeric(10) AS avg_monthly_visits
+           , sum(visit_count)::numeric(10) AS total_visits
+           , PERCENTILE_CONT(0.5) WITHIN GROUP(ORDER BY visit_count)::numeric(10) AS median_monthly_visits
+           , min(visit_count)::numeric(10) AS min_visits
+           , max(visit_count)::numeric(10) AS max_visits
+      FROM (
+        SELECT DATE_TRUNC('month', created_at) AS visit_month
+             , COUNT(*) AS visit_count
+        FROM visits
+        WHERE created_at >= ?
+          AND created_at <= ?
+          AND url LIKE ?
+          AND COALESCE(referrer, '') ILIKE ?
+        GROUP BY DATE_TRUNC('month', created_at)
+      ) visits_by_month
+    SQL
+    Visit.find_by_sql([sql, visit_search.start_datetime, visit_search.end_datetime,
+                       "%#{visit_search.url}%", "%#{visit_search.referrer}%"])
+  end
 end

--- a/app/views/visits/_custom_search.html.erb
+++ b/app/views/visits/_custom_search.html.erb
@@ -19,6 +19,7 @@
           <%= form.date_field :end_date, placeholder: "End date", class: "w-full border border-gray-300 rounded-md px-3 py-2 focus:ring-2 focus:ring-indigo-500 focus:outline-none" %>
         </div>
       </div>
+      <%= form.hidden_field :granularity %>
       <div class="flex justify-end space-x-4 mt-4">
         <%= form.submit "Search", class: "px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 uppercase tracking-wider" %>
         <%= link_to 'Reset', visits_path, class: "px-4 py-2 bg-gray-300 text-gray-700 rounded-md hover:bg-gray-400 hover:text-gray-800 uppercase tracking-wider" %>

--- a/app/views/visits/_quick_filters.html.erb
+++ b/app/views/visits/_quick_filters.html.erb
@@ -1,22 +1,27 @@
 <%# locals: visit_search %>
 
-<div class="mb-4 mt-4">
+<div class="mb-4 mt-4 flex items-center justify-between flex-wrap gap-3">
   <div class="inline-flex items-center divide-x divide-gray-300 border border-indigo-500 rounded-md bg-white">
     <%= quick_filter_link('24 Hours',
           { start_date: 24.hours.ago.to_date, end_date: Time.zone.today },
           { start_date: visit_search.start_date, end_date: visit_search.end_date },
-          visits_path(visit_search: { start_date: 24.hours.ago.to_date, end_date: Time.zone.today })) %>
+          visits_path(visit_search: { start_date: 24.hours.ago.to_date, end_date: Time.zone.today, granularity: visit_search.granularity })) %>
     <%= quick_filter_link('7 Days',
           { start_date: 7.days.ago.to_date, end_date: Time.zone.today },
           { start_date: visit_search.start_date, end_date: visit_search.end_date },
-          visits_path(visit_search: { start_date: 7.days.ago.to_date, end_date: Time.zone.today })) %>
+          visits_path(visit_search: { start_date: 7.days.ago.to_date, end_date: Time.zone.today, granularity: visit_search.granularity })) %>
     <%= quick_filter_link('1 Month',
           { start_date: 1.month.ago.to_date, end_date: Time.zone.today },
           { start_date: visit_search.start_date, end_date: visit_search.end_date },
-          visits_path(visit_search: { start_date: 1.month.ago.to_date, end_date: Time.zone.today })) %>
+          visits_path(visit_search: { start_date: 1.month.ago.to_date, end_date: Time.zone.today, granularity: visit_search.granularity })) %>
     <%= quick_filter_link('3 Months',
           { start_date: 3.months.ago.to_date, end_date: Time.zone.today },
           { start_date: visit_search.start_date, end_date: visit_search.end_date },
-          visits_path(visit_search: { start_date: 3.months.ago.to_date, end_date: Time.zone.today })) %>
+          visits_path(visit_search: { start_date: 3.months.ago.to_date, end_date: Time.zone.today, granularity: visit_search.granularity })) %>
+  </div>
+
+  <div class="inline-flex items-center divide-x divide-gray-300 border border-indigo-500 rounded-md bg-white">
+    <%= granularity_link('Day', 'day', visit_search) %>
+    <%= granularity_link('Month', 'month', visit_search) %>
   </div>
 </div>

--- a/app/views/visits/index.html.erb
+++ b/app/views/visits/index.html.erb
@@ -17,14 +17,16 @@
       </div>
     </div>
 
-    <%# By Date %>
+    <%# By Date / By Month — controlled by granularity toggle %>
     <div class="bg-white shadow-md rounded-md p-4">
-      <h2 class="text-lg font-medium text-gray-800">Visits by Date</h2>
+      <h2 class="text-lg font-medium text-gray-800">
+        <%= @visit_search.monthly? ? 'Visits by Month' : 'Visits by Date' %>
+      </h2>
       <%= render 'line_chart',
-             data: @stats.by_date,
+             data: @visit_search.monthly? ? @stats.by_month : @stats.by_date,
              id: 'by_date',
              height: '325px',
-             xtitle: 'Date',
+             xtitle: @visit_search.monthly? ? 'Month' : 'Date',
              ytitle: 'Number of Visits' %>
     </div>
 

--- a/features/step_definitions/visit_quick_filter_steps.rb
+++ b/features/step_definitions/visit_quick_filter_steps.rb
@@ -12,3 +12,20 @@ end
 Then("the {string} quick filter is not clickable") do |filter_name|
   expect(page).to have_no_link(filter_name)
 end
+
+Then("the {string} granularity toggle is active") do |label|
+  active = find("[data-test-id='granularity-active'][data-label='#{label}']")
+  expect(active).to be_present
+end
+
+Then("the {string} granularity toggle is not clickable") do |label|
+  expect(page).to have_no_link(label, href: /granularity=#{label.downcase}/)
+end
+
+Then("the {string} granularity toggle is clickable") do |label|
+  expect(page).to have_link(label)
+end
+
+When("I click the {string} granularity toggle") do |label|
+  find("[data-test-id='granularity-link'][data-label='#{label}']").click
+end

--- a/features/step_definitions/visit_steps.rb
+++ b/features/step_definitions/visit_steps.rb
@@ -54,6 +54,11 @@ And("charts are displayed") do
   end
 end
 
+Then("the Summary section shows monthly stats") do
+  expect(page).to have_css("[data-test-id='stat-avg_monthly_visits']")
+  expect(page).to have_no_css("[data-test-id='stat-avg_daily_visits']")
+end
+
 Then("charts display no data") do
   within("#by_date") do
     expect(page).to have_content("No data")

--- a/features/visit_analysis.feature
+++ b/features/visit_analysis.feature
@@ -50,3 +50,15 @@ Feature: Visit Analysis
   Scenario: No results
     When I search by content "no-such-thing"
     Then charts display no data
+
+  Scenario: Granularity toggle defaults to Day
+    Then the "Day" granularity toggle is active
+    And the "Day" granularity toggle is not clickable
+    And the "Month" granularity toggle is clickable
+
+  Scenario: Monthly granularity shows monthly summary stats
+    When I click the "Month" granularity toggle
+    Then the "Month" granularity toggle is active
+    And the "Day" granularity toggle is clickable
+    And the Summary section shows monthly stats
+    And charts are displayed

--- a/spec/helpers/visits_helper_spec.rb
+++ b/spec/helpers/visits_helper_spec.rb
@@ -3,6 +3,25 @@
 require "rails_helper"
 
 RSpec.describe VisitsHelper do
+  describe "#granularity_link" do
+    let(:visit_search) { VisitSearch.new(granularity: "day") }
+
+    it "renders a span with active styles when the value matches granularity" do
+      result = helper.granularity_link("Day", "day", visit_search)
+      expect(result).to include("<span")
+      expect(result).to include("bg-indigo-100")
+      expect(result).to include("text-indigo-600")
+      expect(result).to include("data-test-id=\"granularity-active\"")
+    end
+
+    it "renders a link for the inactive value" do
+      result = helper.granularity_link("Month", "month", visit_search)
+      expect(result).to include("<a")
+      expect(result).to include("hover:bg-gray-100")
+      expect(result).not_to include("bg-indigo-100")
+    end
+  end
+
   describe "#quick_filter_link" do
     let(:range) { { start_date: 7.days.ago.to_date, end_date: Time.zone.today } }
     let(:current_range) { { start_date: 7.days.ago.to_date, end_date: Time.zone.today } }

--- a/spec/models/stats_spec.rb
+++ b/spec/models/stats_spec.rb
@@ -71,4 +71,29 @@ RSpec.describe Stats do
       expect(stats.by_date).to eq([[1.day.ago.to_date.to_s, 2]])
     end
   end
+
+  context "when granularity is monthly" do
+    it "populates by_month and monthly summary, leaves by_date nil" do
+      create_list(:visit, 3, created_at: 40.days.ago)
+      create_list(:visit, 5, created_at: 5.days.ago)
+
+      visit_search = VisitSearch.new(
+        start_date: 2.months.ago.to_date,
+        end_date: Time.zone.today,
+        url: "",
+        referrer: "",
+        granularity: "month"
+      )
+      stats = described_class.new(visit_search)
+      stats.collect
+
+      expect(stats.by_month).not_to be_nil
+      expect(stats.by_month.length).to eq(2)
+      expect(stats.by_date).to be_nil
+
+      expect(stats.summary[:avg_monthly_visits]).to eq(4)
+      expect(stats.summary[:total_visits]).to eq(8)
+      expect(stats.summary).not_to have_key(:avg_daily_visits)
+    end
+  end
 end

--- a/spec/models/visit_search_spec.rb
+++ b/spec/models/visit_search_spec.rb
@@ -37,6 +37,20 @@ RSpec.describe VisitSearch do
     end
   end
 
+  describe "granularity" do
+    it "defaults to 'day'" do
+      expect(described_class.new.granularity).to eq("day")
+    end
+
+    it "monthly? returns false when granularity is 'day'" do
+      expect(described_class.new(granularity: "day").monthly?).to be(false)
+    end
+
+    it "monthly? returns true when granularity is 'month'" do
+      expect(described_class.new(granularity: "month").monthly?).to be(true)
+    end
+  end
+
   describe "#end_datetime" do
     it "returns the end of the day for end_date" do
       visit_search = described_class.new(end_date: "2024-12-25")

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -120,6 +120,35 @@ RSpec.describe Visit do
     end
   end
 
+  describe "by_month" do
+    it "returns an array of arrays grouped by month in date order" do
+      create_list(:visit, 3, created_at: 40.days.ago)  # prior month
+      create_list(:visit, 5, created_at: 5.days.ago)   # current month
+
+      result = described_class.by_month(VisitSearch.new(start_date: 2.months.ago.to_date))
+
+      expect(result.length).to eq(2)
+      expect(result[0][1]).to eq(3)  # earlier month
+      expect(result[1][1]).to eq(5)  # current month
+    end
+  end
+
+  describe "monthly_summary" do
+    it "returns summary stats aggregated by month" do
+      create_list(:visit, 3, created_at: 40.days.ago)  # prior month: 3
+      create_list(:visit, 5, created_at: 5.days.ago)   # current month: 5
+
+      visit_search = VisitSearch.new(start_date: 2.months.ago.to_date, granularity: "month")
+      result = described_class.monthly_summary(visit_search)
+
+      expect(result[:total_visits]).to eq(8)
+      expect(result[:min_visits]).to eq(3)
+      expect(result[:max_visits]).to eq(5)
+      expect(result[:avg_monthly_visits]).to eq(4)
+      expect(result[:median_monthly_visits]).to eq(4)
+    end
+  end
+
   describe "by_date" do
     it "Returns an array of arrays by date order, representing visits grouped by date" do
       visit1 = create(:visit, url: "https://example.com/page1", created_at: 5.days.ago)


### PR DESCRIPTION
## Summary

- Adds a Day/Month toggle button group to the quick filters bar, letting users switch between daily and monthly chart granularity
- Monthly mode uses `DATE_TRUNC`-based SQL aggregations and shows `avg/median/min/max` monthly visit stats instead of the daily equivalents
- Granularity is preserved across quick filter clicks, search form submissions, and page navigations

## Test plan

- [ ] `bin/rspec` — 50 examples, 0 failures
- [ ] `bin/rubocop` — no offenses
- [ ] `bin/cucumber` — 12 scenarios, 59 steps, all passing
- [ ] Manual: visit dashboard, click Month toggle, verify monthly stats and chart appear; click a quick filter or submit Search, verify granularity is retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)