### PR TITLE
Pin chartkick < 5.2.1 to fix animation regression

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "devise"
 gem "rack-cors"
 gem "pg_search"
 gem "font-awesome-rails"
-gem "chartkick"
+gem "chartkick", "< 5.2.1" # chart.js 4.5.1 breaks animation (chartjs/Chart.js#12143); remove pin when chartkick >= 5.2.2
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
     capybara-screenshot (1.0.26)
       capybara (>= 1.0, < 4)
       launchy
-    chartkick (5.2.1)
+    chartkick (5.2.0)
     childprocess (5.1.0)
       logger (~> 1.5)
     concurrent-ruby (1.3.6)
@@ -505,7 +505,7 @@ DEPENDENCIES
   browser
   capybara
   capybara-screenshot
-  chartkick
+  chartkick (< 5.2.1)
   cucumber-rails
   cuprite
   database_cleaner-active_record


### PR DESCRIPTION
## Summary

- Pins `chartkick` to `< 5.2.1` to avoid a Chart.js 4.5.1 regression that breaks initial chart animations
- Chart.js 4.5.1 (bundled in chartkick 5.2.1) changed `retinaScale` to use `round1` instead of `Math.floor`, producing non-integer device dimensions that never equal the integer canvas dimensions — so `retinaScale` always returns `true`, triggering rapid `update()` calls that kill the animation before it renders a frame
- Regression tracked in [chartjs/Chart.js#12143](https://github.com/chartjs/Chart.js/issues/12143); a fix exists in PR #12142 but hasn't shipped yet
- Remove the version pin when chartkick ≥ 5.2.2 releases with a patched Chart.js

## Test plan

- [ ] `bin/dev` starts without errors
- [ ] Dashboard charts animate on page load (bar chart and line chart)
- [ ] Animation works on retina displays / high-DPI screens
- [ ] `bin/ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)