### PR TITLE
Reduce dependabot noise: monthly schedule + gem groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,25 @@ updates:
 - package-ecosystem: bundler
   directory: "/"
   schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+    interval: monthly
+  open-pull-requests-limit: 5
+  groups:
+    rubocop:
+      patterns:
+        - "rubocop*"
+    solid-rails:
+      patterns:
+        - "solid_*"
+    test-tooling:
+      patterns:
+        - "faker"
+        - "factory_bot*"
+        - "shoulda*"
+        - "capybara*"
+        - "cuprite"
+        - "database_cleaner*"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: monthly
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary

- Switch Bundler from `daily` to `monthly` schedule — the daily cadence was opening 10+ individual PRs per run, overwhelming the queue
- Add dependency groups so rubocop plugins, `solid_*` gems, and test tooling each arrive as one PR instead of one per gem
- Lower `open-pull-requests-limit` (Bundler: 10→5, GitHub Actions: 10→3) to stay well under the cap

## Expected impact

Before: ~10 individual PRs per daily run, hitting the cap and blocking new updates
After: ~3–4 grouped PRs per month

## Test plan

- [ ] Verify dependabot.yml is valid YAML (no syntax errors)
- [ ] Confirm groups match the gems we actually use in Gemfile
- [ ] After merge, monitor next dependabot run to confirm grouped PRs appear as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)