### PR TITLE
Add trigram index on visits.url for substring search performance

### DIFF
--- a/.pgsync.yml
+++ b/.pgsync.yml
@@ -1,0 +1,7 @@
+from: $(heroku config:get DATABASE_URL --app $HEROKU_HELLO_APP_NAME)?sslmode=require
+to: postgres://hello:hello@127.0.0.1/hello
+
+exclude:
+  - users
+  - schema_migrations
+  - ar_internal_metadata

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## About
 
-Hello Visitor is a privacy-focused analytics app built with Rails 8.1. It records page visits without tracking cookies. The dashboard shows visit statistics filtered by URL, referrer, and date range.
+Hello Visitor is a privacy-focused analytics app built with Rails 8.1. It records page visits without tracking cookies. The dashboard shows visit statistics filtered by URL, referrer, and date range. Hosted on Heroku with the Heroku Postgres add-on.
 
 ## Commands
 
@@ -36,6 +36,13 @@ make replant       # Reseed database (drop + seed)
 make console       # Open Rails console
 make routes        # Print routes
 ```
+
+Sync production visits data locally (requires `$HEROKU_HELLO_APP_NAME` env var set and `heroku` CLI authenticated):
+```bash
+pgsync visits      # Truncates local visits table and bulk-copies prod rows in
+```
+
+`.pgsync.yml` in the project root configures the source (Heroku Postgres) and destination (local dev DB). The `users` table is excluded so local Devise credentials stay intact.
 
 ## Architecture
 

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  gem "pgsync", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,6 +288,12 @@ GEM
     pg_search (2.3.7)
       activerecord (>= 6.1)
       activesupport (>= 6.1)
+    pgsync (0.8.1)
+      bigdecimal
+      parallel
+      pg (>= 0.18.2)
+      slop (>= 4.10.1)
+      tty-spinner
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -423,6 +429,7 @@ GEM
     securerandom (0.4.1)
     shoulda-matchers (7.0.1)
       activesupport (>= 7.1)
+    slop (4.10.1)
     solid_cable (3.0.12)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -468,6 +475,9 @@ GEM
     thruster (0.1.17-x86_64-linux)
     timeout (0.6.1)
     tsort (0.2.0)
+    tty-cursor (0.7.1)
+    tty-spinner (0.9.3)
+      tty-cursor (~> 0.7)
     turbo-rails (2.0.16)
       actionpack (>= 7.1.0)
       railties (>= 7.1.0)
@@ -524,6 +534,7 @@ DEPENDENCIES
   kamal
   pg (~> 1.6)
   pg_search
+  pgsync
   propshaft
   puma (>= 5.0)
   rack-cors

--- a/db/migrate/20260523215642_add_trigram_index_to_visits_url.rb
+++ b/db/migrate/20260523215642_add_trigram_index_to_visits_url.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddTrigramIndexToVisitsUrl < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    enable_extension "pg_trgm"
+    add_index :visits, :url, using: :gin,
+                             opclass: :gin_trgm_ops,
+                             algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_04_190355) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_23_215642) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+  enable_extension "pg_trgm"
 
   create_table "documents", force: :cascade do |t|
     t.text "body", null: false
@@ -48,5 +49,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_04_190355) do
     t.string "url", null: false
     t.string "user_agent", null: false
     t.index ["created_at"], name: "index_visits_on_created_at"
+    t.index ["url"], name: "index_visits_on_url", opclass: :gin_trgm_ops, using: :gin
   end
 end


### PR DESCRIPTION
## Summary

- Enables the `pg_trgm` PostgreSQL extension and adds a GIN trigram index on `visits.url`
- All 7 `VisitQuery` methods use `url LIKE '%...%'` (leading-wildcard) which a standard B-tree index cannot accelerate — the trigram index allows these to use an index scan instead of a full sequential scan at scale
- Uses `disable_ddl_transaction!` + `algorithm: :concurrently` so the index builds without locking the table on live databases
- Also sets up `pgsync` for syncing production visits data locally to support future performance testing

## Test plan

- [ ] `bin/ci` passes (all RSpec + Cucumber + Rubocop)
- [ ] `make migrate` applies cleanly with no errors
- [ ] `ActiveRecord::Base.connection.indexes(:visits)` shows `index_visits_on_url` with `using: :gin`
- [ ] `db/schema.rb` lists the new index and `enable_extension "pg_trgm"`

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)