### PR TITLE
Add VisitQuery unit tests and eliminate WHERE clause duplication (#213, #214)

### DIFF
--- a/app/queries/visit_query.rb
+++ b/app/queries/visit_query.rb
@@ -3,6 +3,7 @@
 class VisitQuery
   MAX_GROUPS = 10
   MAX_GROUPS_BOTTOM = 5
+  BASE_WHERE_CLAUSE = "created_at >= ? AND created_at <= ? AND url LIKE ? AND COALESCE(referrer, '') ILIKE ?"
 
   def self.summary(visit_search)
     sql = <<~SQL.squish
@@ -15,14 +16,10 @@ class VisitQuery
       (SELECT created_at::timestamp::date as visit_date
            , count(created_at::timestamp::date) as visit_count
       FROM visits
-      WHERE created_at >= ?
-        AND created_at <= ?
-        AND url like ?
-        AND COALESCE(referrer, '') ILIKE ?
+      WHERE #{BASE_WHERE_CLAUSE}
       GROUP BY created_at::timestamp::date) visits_by_day
     SQL
-    Visit.find_by_sql([sql, visit_search.start_datetime, visit_search.end_datetime, "%#{visit_search.url}%",
-                       "%#{visit_search.referrer}%"])
+    Visit.find_by_sql([sql, *base_params(visit_search)])
   end
 
   def self.by_page(visit_search)
@@ -30,16 +27,12 @@ class VisitQuery
       SELECT SPLIT_PART(url, ?, 1) as just_url
         , count(SPLIT_PART(url, ?, 1)) as page_count
       FROM visits
-      WHERE created_at >= ?
-        AND created_at <= ?
-        AND url like ?
-        AND COALESCE(referrer, '') ILIKE ?
+      WHERE #{BASE_WHERE_CLAUSE}
       GROUP BY SPLIT_PART(url, ?, 1)
       ORDER BY count(SPLIT_PART(url, ?, 1)) desc
       LIMIT #{MAX_GROUPS}
     SQL
-    Visit.find_by_sql([sql, "?", "?", visit_search.start_datetime, visit_search.end_datetime, "%#{visit_search.url}%",
-                       "%#{visit_search.referrer}%", "?", "?"])
+    Visit.find_by_sql([sql, "?", "?", *base_params(visit_search), "?", "?"])
   end
 
   def self.by_page_bottom(visit_search)
@@ -47,16 +40,12 @@ class VisitQuery
       SELECT SPLIT_PART(url, ?, 1) as just_url
         , count(SPLIT_PART(url, ?, 1)) as page_count
       FROM visits
-      WHERE created_at >= ?
-        AND created_at <= ?
-        AND url like ?
-        AND COALESCE(referrer, '') ILIKE ?
+      WHERE #{BASE_WHERE_CLAUSE}
       GROUP BY SPLIT_PART(url, ?, 1)
       ORDER BY count(SPLIT_PART(url, ?, 1)) ASC
       LIMIT #{MAX_GROUPS_BOTTOM}
     SQL
-    Visit.find_by_sql([sql, "?", "?", visit_search.start_datetime, visit_search.end_datetime, "%#{visit_search.url}%",
-                       "%#{visit_search.referrer}%", "?", "?"])
+    Visit.find_by_sql([sql, "?", "?", *base_params(visit_search), "?", "?"])
   end
 
   def self.by_referrer(visit_search)
@@ -64,17 +53,13 @@ class VisitQuery
       select trim(trailing '/' from referrer) as referrer
         , count(trim(trailing '/' from referrer)) as visit_count
       from visits
-      where created_at >= ?
-        AND created_at <= ?
-        AND url like ?
-        AND COALESCE(referrer, '') ILIKE ?
+      where #{BASE_WHERE_CLAUSE}
         and length(referrer) > 0
       group by trim(trailing '/' from referrer)
       order by count(trim(trailing '/' from referrer)) desc
       LIMIT #{MAX_GROUPS}
     SQL
-    Visit.find_by_sql([sql, visit_search.start_datetime, visit_search.end_datetime, "%#{visit_search.url}%",
-                       "%#{visit_search.referrer}%"])
+    Visit.find_by_sql([sql, *base_params(visit_search)])
   end
 
   def self.by_date(visit_search)
@@ -82,15 +67,11 @@ class VisitQuery
       SELECT created_at::timestamp::date as visit_date
         , count(created_at::timestamp::date) as visit_count
       FROM visits
-      WHERE created_at >= ?
-        AND created_at <= ?
-        AND url like ?
-        AND COALESCE(referrer, '') ILIKE ?
+      WHERE #{BASE_WHERE_CLAUSE}
       GROUP BY created_at::timestamp::date
       ORDER BY created_at::timestamp::date
     SQL
-    Visit.find_by_sql([sql, visit_search.start_datetime, visit_search.end_datetime, "%#{visit_search.url}%",
-                       "%#{visit_search.referrer}%"])
+    Visit.find_by_sql([sql, *base_params(visit_search)])
   end
 
   def self.by_month(visit_search)
@@ -98,15 +79,11 @@ class VisitQuery
       SELECT DATE_TRUNC('month', created_at) AS visit_month
            , COUNT(*) AS visit_count
       FROM visits
-      WHERE created_at >= ?
-        AND created_at <= ?
-        AND url LIKE ?
-        AND COALESCE(referrer, '') ILIKE ?
+      WHERE #{BASE_WHERE_CLAUSE}
       GROUP BY DATE_TRUNC('month', created_at)
       ORDER BY DATE_TRUNC('month', created_at)
     SQL
-    Visit.find_by_sql([sql, visit_search.start_datetime, visit_search.end_datetime,
-                       "%#{visit_search.url}%", "%#{visit_search.referrer}%"])
+    Visit.find_by_sql([sql, *base_params(visit_search)])
   end
 
   def self.monthly_summary(visit_search)
@@ -120,14 +97,21 @@ class VisitQuery
         SELECT DATE_TRUNC('month', created_at) AS visit_month
              , COUNT(*) AS visit_count
         FROM visits
-        WHERE created_at >= ?
-          AND created_at <= ?
-          AND url LIKE ?
-          AND COALESCE(referrer, '') ILIKE ?
+        WHERE #{BASE_WHERE_CLAUSE}
         GROUP BY DATE_TRUNC('month', created_at)
       ) visits_by_month
     SQL
-    Visit.find_by_sql([sql, visit_search.start_datetime, visit_search.end_datetime,
-                       "%#{visit_search.url}%", "%#{visit_search.referrer}%"])
+    Visit.find_by_sql([sql, *base_params(visit_search)])
   end
+
+  def self.base_params(visit_search)
+    [
+      visit_search.start_datetime,
+      visit_search.end_datetime,
+      "%#{visit_search.url}%",
+      "%#{visit_search.referrer}%"
+    ]
+  end
+
+  private_class_method :base_params
 end

--- a/spec/queries/visit_query_spec.rb
+++ b/spec/queries/visit_query_spec.rb
@@ -1,0 +1,328 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe VisitQuery do
+  let(:default_search) { VisitSearch.new }
+
+  describe ".summary" do
+    it "returns correct aggregate values for the date range" do
+      create_list(:visit, 10, created_at: 60.days.ago)
+      create_list(:visit, 2, created_at: 30.days.ago)
+      create_list(:visit, 6, created_at: 10.days.ago)
+
+      visit_search = VisitSearch.new(start_date: 90.days.ago.to_date)
+      result = described_class.summary(visit_search)
+
+      expect(result[0]["total_visits"]).to eq(18)
+      expect(result[0]["min_visits"]).to eq(2)
+      expect(result[0]["max_visits"]).to eq(10)
+      expect(result[0]["avg_daily_visits"]).to eq(6)
+      expect(result[0]["median_daily_visits"]).to eq(6)
+    end
+
+    it "excludes visits outside the date range" do
+      create_list(:visit, 5, created_at: 2.days.ago)
+      create_list(:visit, 10, created_at: 400.days.ago)
+
+      visit_search = VisitSearch.new(start_date: 7.days.ago.to_date)
+      result = described_class.summary(visit_search)
+
+      expect(result[0]["total_visits"]).to eq(5)
+    end
+
+    it "filters by url (LIKE)" do
+      create(:visit, url: "https://example.com/page1")
+      create(:visit, url: "https://example.com/page1")
+      create(:visit, url: "https://example.com/about")
+
+      visit_search = VisitSearch.new(url: "page1")
+      result = described_class.summary(visit_search)
+
+      expect(result[0]["total_visits"]).to eq(2)
+    end
+
+    it "filters by referrer case-insensitively (ILIKE)" do
+      create(:visit, referrer: "https://www.Google.com")
+      create(:visit, referrer: "https://www.google.com")
+      create(:visit, referrer: "https://www.bing.com")
+
+      visit_search = VisitSearch.new(referrer: "google")
+      result = described_class.summary(visit_search)
+
+      expect(result[0]["total_visits"]).to eq(2)
+    end
+  end
+
+  describe ".by_page" do
+    it "returns results ordered by count DESC" do
+      create(:visit, url: "https://example.com/page1")
+      create(:visit, url: "https://example.com/page2")
+      create(:visit, url: "https://example.com/page2")
+
+      result = described_class.by_page(default_search)
+
+      expect(result[0]["just_url"]).to eq("https://example.com/page2")
+      expect(result[0]["page_count"]).to eq(2)
+      expect(result[1]["just_url"]).to eq("https://example.com/page1")
+      expect(result[1]["page_count"]).to eq(1)
+    end
+
+    it "strips query string from URL via SPLIT_PART" do
+      create(:visit, url: "https://example.com/page?foo=bar")
+      create(:visit, url: "https://example.com/page?baz=1")
+
+      result = described_class.by_page(default_search)
+
+      expect(result.length).to eq(1)
+      expect(result[0]["just_url"]).to eq("https://example.com/page")
+      expect(result[0]["page_count"]).to eq(2)
+    end
+
+    it "filters by url" do
+      create(:visit, url: "https://example.com/page1")
+      create(:visit, url: "https://example.com/about")
+
+      visit_search = VisitSearch.new(url: "page1")
+      result = described_class.by_page(visit_search)
+
+      expect(result.length).to eq(1)
+      expect(result[0]["just_url"]).to eq("https://example.com/page1")
+    end
+
+    it "excludes visits outside the date range" do
+      create(:visit, url: "https://example.com/page1", created_at: 2.days.ago)
+      create(:visit, url: "https://example.com/page1", created_at: 400.days.ago)
+
+      visit_search = VisitSearch.new(start_date: 7.days.ago.to_date)
+      result = described_class.by_page(visit_search)
+
+      expect(result.length).to eq(1)
+      expect(result[0]["page_count"]).to eq(1)
+    end
+
+    it "limits to MAX_GROUPS (10) records" do
+      11.times { |i| create(:visit, url: "https://example.com/page#{i}") }
+
+      result = described_class.by_page(default_search)
+
+      expect(result.length).to eq(VisitQuery::MAX_GROUPS)
+    end
+  end
+
+  describe ".by_page_bottom" do
+    it "returns results ordered by count ASC" do
+      create(:visit, url: "https://example.com/page1")
+      create(:visit, url: "https://example.com/page2")
+      create(:visit, url: "https://example.com/page2")
+
+      result = described_class.by_page_bottom(default_search)
+
+      expect(result[0]["just_url"]).to eq("https://example.com/page1")
+      expect(result[0]["page_count"]).to eq(1)
+      expect(result[1]["just_url"]).to eq("https://example.com/page2")
+      expect(result[1]["page_count"]).to eq(2)
+    end
+
+    it "limits to MAX_GROUPS_BOTTOM (5) records" do
+      10.times { |i| create(:visit, url: "https://example.com/page#{i}") }
+
+      result = described_class.by_page_bottom(default_search)
+
+      expect(result.length).to eq(VisitQuery::MAX_GROUPS_BOTTOM)
+    end
+
+    it "filters by url" do
+      create(:visit, url: "https://example.com/page1")
+      create(:visit, url: "https://example.com/about")
+
+      visit_search = VisitSearch.new(url: "page1")
+      result = described_class.by_page_bottom(visit_search)
+
+      expect(result.length).to eq(1)
+      expect(result[0]["just_url"]).to eq("https://example.com/page1")
+    end
+
+    it "excludes visits outside the date range" do
+      create(:visit, url: "https://example.com/page1", created_at: 2.days.ago)
+      create(:visit, url: "https://example.com/page1", created_at: 400.days.ago)
+
+      visit_search = VisitSearch.new(start_date: 7.days.ago.to_date)
+      result = described_class.by_page_bottom(visit_search)
+
+      expect(result.length).to eq(1)
+      expect(result[0]["page_count"]).to eq(1)
+    end
+
+    it "returns the least-visited URLs (different from by_page when more than MAX_GROUPS_BOTTOM URLs exist)" do
+      # page0: 1 visit, page1: 2, page2: 3, page3: 4, page4: 5, page5: 6
+      6.times { |i| create_list(:visit, i + 1, url: "https://example.com/page#{i}") }
+
+      top = described_class.by_page(default_search)
+      bottom = described_class.by_page_bottom(default_search)
+
+      expect(top[0]["just_url"]).to include("page5") # most visited
+      expect(bottom[0]["just_url"]).to include("page0") # least visited
+    end
+  end
+
+  describe ".by_referrer" do
+    it "returns results ordered by count DESC" do
+      create(:visit, referrer: "https://www.google.com")
+      create(:visit, referrer: "https://www.google.com")
+      create(:visit, referrer: "https://www.bing.com")
+
+      result = described_class.by_referrer(default_search)
+
+      expect(result[0]["referrer"]).to eq("https://www.google.com")
+      expect(result[0]["visit_count"]).to eq(2)
+      expect(result[1]["referrer"]).to eq("https://www.bing.com")
+      expect(result[1]["visit_count"]).to eq(1)
+    end
+
+    it "excludes visits with no referrer" do
+      create_list(:visit, 5)
+      create(:visit, referrer: "https://www.google.com")
+
+      result = described_class.by_referrer(default_search)
+
+      expect(result.length).to eq(1)
+      expect(result[0]["referrer"]).to eq("https://www.google.com")
+    end
+
+    it "strips trailing slash from referrer" do
+      create(:visit, referrer: "https://www.google.com/")
+      create(:visit, referrer: "https://www.google.com/")
+
+      result = described_class.by_referrer(default_search)
+
+      expect(result.length).to eq(1)
+      expect(result[0]["referrer"]).to eq("https://www.google.com")
+      expect(result[0]["visit_count"]).to eq(2)
+    end
+
+    it "filters by url" do
+      create(:visit, url: "https://example.com/page1", referrer: "https://www.google.com")
+      create(:visit, url: "https://example.com/about", referrer: "https://www.bing.com")
+
+      visit_search = VisitSearch.new(url: "page1")
+      result = described_class.by_referrer(visit_search)
+
+      expect(result.length).to eq(1)
+      expect(result[0]["referrer"]).to eq("https://www.google.com")
+    end
+
+    it "limits to MAX_GROUPS (10) records" do
+      11.times { |i| create(:visit, referrer: "https://referrer#{i}.com") }
+
+      result = described_class.by_referrer(default_search)
+
+      expect(result.length).to eq(VisitQuery::MAX_GROUPS)
+    end
+  end
+
+  describe ".by_date" do
+    it "returns results ordered by date ASC" do
+      create(:visit, created_at: 5.days.ago)
+      create(:visit, created_at: 1.day.ago)
+
+      result = described_class.by_date(default_search)
+
+      expect(result.length).to eq(2)
+      expect(result[0]["visit_date"]).to be < result[1]["visit_date"]
+    end
+
+    it "groups multiple visits on the same day into one row" do
+      create(:visit, created_at: 2.days.ago)
+      create(:visit, created_at: 2.days.ago)
+      create(:visit, created_at: 1.day.ago)
+
+      result = described_class.by_date(default_search)
+
+      expect(result.length).to eq(2)
+      expect(result[0]["visit_count"]).to eq(2)
+      expect(result[1]["visit_count"]).to eq(1)
+    end
+
+    it "excludes visits outside the date range" do
+      create(:visit, created_at: 2.days.ago)
+      create(:visit, created_at: 400.days.ago)
+
+      visit_search = VisitSearch.new(start_date: 7.days.ago.to_date)
+      result = described_class.by_date(visit_search)
+
+      expect(result.length).to eq(1)
+    end
+
+    it "filters by url" do
+      create(:visit, url: "https://example.com/page1", created_at: 1.day.ago)
+      create(:visit, url: "https://example.com/about", created_at: 1.day.ago)
+
+      visit_search = VisitSearch.new(url: "page1")
+      result = described_class.by_date(visit_search)
+
+      expect(result.length).to eq(1)
+      expect(result[0]["visit_count"]).to eq(1)
+    end
+  end
+
+  describe ".by_month" do
+    it "returns results ordered by month ASC" do
+      create_list(:visit, 3, created_at: 40.days.ago)
+      create_list(:visit, 5, created_at: 5.days.ago)
+
+      visit_search = VisitSearch.new(start_date: 2.months.ago.to_date)
+      result = described_class.by_month(visit_search)
+
+      expect(result.length).to eq(2)
+      expect(result[0]["visit_month"]).to be < result[1]["visit_month"]
+    end
+
+    it "groups visits in the same month into one row" do
+      create_list(:visit, 4, created_at: 40.days.ago)
+
+      visit_search = VisitSearch.new(start_date: 2.months.ago.to_date)
+      result = described_class.by_month(visit_search)
+
+      expect(result.length).to eq(1)
+      expect(result[0]["visit_count"]).to eq(4)
+    end
+
+    it "excludes visits outside the date range" do
+      create_list(:visit, 3, created_at: 5.days.ago)
+      create_list(:visit, 5, created_at: 400.days.ago)
+
+      visit_search = VisitSearch.new(start_date: 30.days.ago.to_date)
+      result = described_class.by_month(visit_search)
+
+      expect(result.length).to eq(1)
+      expect(result[0]["visit_count"]).to eq(3)
+    end
+  end
+
+  describe ".monthly_summary" do
+    it "returns correct aggregate values by month" do
+      create_list(:visit, 3, created_at: 40.days.ago)
+      create_list(:visit, 5, created_at: 5.days.ago)
+
+      visit_search = VisitSearch.new(start_date: 2.months.ago.to_date, granularity: "month")
+      result = described_class.monthly_summary(visit_search)
+
+      expect(result[0]["total_visits"]).to eq(8)
+      expect(result[0]["min_visits"]).to eq(3)
+      expect(result[0]["max_visits"]).to eq(5)
+      expect(result[0]["avg_monthly_visits"]).to eq(4)
+      expect(result[0]["median_monthly_visits"]).to eq(4)
+    end
+
+    it "excludes visits outside the date range" do
+      create_list(:visit, 3, created_at: 5.days.ago)
+      create_list(:visit, 5, created_at: 400.days.ago)
+
+      visit_search = VisitSearch.new(start_date: 30.days.ago.to_date, granularity: "month")
+      result = described_class.monthly_summary(visit_search)
+
+      expect(result[0]["total_visits"]).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `spec/queries/visit_query_spec.rb` with 28 direct unit tests for all 7 `VisitQuery` methods (closes #213)
- Extracts the shared WHERE clause into a `BASE_WHERE_CLAUSE` constant and `base_params` private class method, reducing 7 copy-pasted WHERE clauses to one definition each (closes #214)
- Previously untested behaviors now covered: `by_page_bottom` ordering (ASC) and limit (5), URL LIKE and referrer ILIKE filters at the `VisitQuery` level, and SPLIT_PART query-string stripping

## Test plan

- [ ] `bin/rspec spec/queries/visit_query_spec.rb` — 28 examples, 0 failures
- [ ] `bin/ci` — Brakeman clean, RuboCop clean, RSpec 78 examples, Cucumber 12 scenarios all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)