### PR TITLE
Scope skip_forgery_protection to create action only

### DIFF
--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -3,7 +3,7 @@
 class VisitsController < ApplicationController
   before_action :authenticate_user!, only: %i[index show]
   before_action :log_request, only: %i[create]
-  skip_forgery_protection
+  skip_forgery_protection only: :create
 
   def index
     @visit_search = VisitSearch.new


### PR DESCRIPTION
Closes #229

## Summary

- Adds `only: :create` to the bare `skip_forgery_protection` call in `VisitsController`
- The `create` action legitimately needs the CSRF exemption (cross-origin tracking POSTs); `index` and `show` do not
- Applies least-privilege — the intent is now self-documenting in the code

## Test plan

- [x] `bin/rspec` — 78 tests, all pass
- [x] `bin/cucumber` — 12 scenarios, all pass (including authenticated dashboard flows)
- [x] Diff is one line in one file

🤖 Generated with [Claude Code](https://claude.com/claude-code)