### PR TITLE
PR 1 — Add referrer_group column and concurrent index to visits

### DIFF
--- a/db/migrate/20260608105742_add_referrer_group_to_visits.rb
+++ b/db/migrate/20260608105742_add_referrer_group_to_visits.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReferrerGroupToVisits < ActiveRecord::Migration[8.1]
+  def change
+    add_column :visits, :referrer_group, :string
+  end
+end

--- a/db/migrate/20260608110049_add_index_to_visits_referrer_group.rb
+++ b/db/migrate/20260608110049_add_index_to_visits_referrer_group.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndexToVisitsReferrerGroup < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :visits, :referrer_group, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_23_215642) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_08_110049) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -44,11 +44,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_23_215642) do
     t.datetime "created_at", null: false
     t.integer "guest_timezone_offset", null: false
     t.string "referrer"
+    t.string "referrer_group"
     t.string "remote_ip"
     t.datetime "updated_at", null: false
     t.string "url", null: false
     t.string "user_agent", null: false
     t.index ["created_at"], name: "index_visits_on_created_at"
+    t.index ["referrer_group"], name: "index_visits_on_referrer_group"
     t.index ["url"], name: "index_visits_on_url", opclass: :gin_trgm_ops, using: :gin
   end
 end


### PR DESCRIPTION
## Summary

- Add nullable `referrer_group` string column to `visits` (`NULL` reserved as the sentinel for "Direct" visits per the consolidation algorithm).
- Add a concurrent B-tree index on `visits.referrer_group` to support GROUP BY / ORDER BY in PR 4's `by_referrer` query rewrite.
- No code reads or writes the column yet — this is the "expand" step of an expand → migrate → contract rollout. PRs 2–4 follow.

This is PR 1 of 4. Detailed plan: [scratch/referrer-consolidation/PR1-schema.md](../blob/main/scratch/referrer-consolidation/PR1-schema.md).

Refs #245
Parent: #244

## Test plan

- [x] `bin/rspec` green (baseline + after)
- [x] `bin/cucumber` green (baseline + after)
- [x] `bin/rubocop` clean (baseline + after)
- [x] `bin/ci` green after both migrations applied
- [x] `db/schema.rb` regenerated cleanly — only the version line, the new column line, and the new index line changed
- [ ] After merge: watch Heroku deploy logs for both migrations
- [ ] After merge: `\d visits` on prod shows `referrer_group` column and `index_visits_on_referrer_group`
- [ ] After merge: `SELECT count(*) FROM visits WHERE referrer_group IS NOT NULL;` returns `0`
- [ ] After merge: no POST /visits p95 regression during the deploy window

🤖 Generated with [Claude Code](https://claude.com/claude-code)