### PR TITLE
Bump brakeman from 8.0.4 to 8.0.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.24.5)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     browser (6.2.0)
     builder (3.3.0)


### PR DESCRIPTION
## Summary

- `bin/brakeman` runs with `--ensure-latest`, so any brakeman release older than the current latest fails the brakeman step in `bin/ci` and on Heroku CI.
- Bumping from 8.0.4 to 8.0.5 unblocks CI. No scan findings change (0 warnings before, 0 warnings after).
- Prep PR ahead of #246 (referrer normalizer + write-path), so that PR's CI runs on a green baseline.

## Test plan

- [x] `bin/brakeman --no-pager` exits 0
- [x] `bin/rspec` green
- [x] `bin/rubocop` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)