### PR TITLE
Classify new visits into consolidated referrer groups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Hello Visitor is a privacy-focused analytics app built with Rails 8.1. It records page visits without tracking cookies. The dashboard shows visit statistics filtered by URL, referrer, and date range. Hosted on Heroku with the Heroku Postgres add-on.
 
+## Code quality
+
+Do not disable Rubocop rules (no inline `# rubocop:disable ...`, no per-file or per-cop overrides in `.rubocop.yml`, no new entries in `.rubocop_todo.yml`) when adding new code. Treat a rule violation as a signal that the code is doing too much or is too dense, and fix the underlying smell — usually by extracting a method, moving logic into the model, or splitting a class. The existing entries in `.rubocop_todo.yml` are legacy; we are trying to chip away at them, not add to them. If a rule is genuinely wrong for this project (not just inconvenient for one method), raise it for discussion before changing config.
+
 ## Commands
 
 ```bash

--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -23,11 +23,8 @@ class VisitsController < ApplicationController
     render json: { visits: @visit }
   end
 
-  def create # rubocop:disable Metrics/AbcSize
-    @visit = Visit.new(visit_params)
-    @visit.remote_ip = request.remote_ip
-    @visit.referrer_group = ReferrerNormalizer.group_for(@visit.referrer)
-    sanitize
+  def create
+    @visit = IncomingVisit.new(params: visit_params, remote_ip: request.remote_ip).build
 
     if @visit.save
       Rails.logger.info("Visit saved: id=#{@visit.id}, url=#{@visit.url}")
@@ -45,12 +42,6 @@ class VisitsController < ApplicationController
 
   def visit_search_params
     params.expect(visit_search: %i[url referrer start_date end_date granularity])
-  end
-
-  # https://stackoverflow.com/questions/3985989/using-sanitize-within-a-rails-controller
-  def sanitize
-    @visit.user_agent = ActionController::Base.helpers.sanitize(@visit.user_agent)
-    @visit.url = ActionController::Base.helpers.sanitize(@visit.url)
   end
 
   def log_request

--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -23,9 +23,10 @@ class VisitsController < ApplicationController
     render json: { visits: @visit }
   end
 
-  def create
+  def create # rubocop:disable Metrics/AbcSize
     @visit = Visit.new(visit_params)
     @visit.remote_ip = request.remote_ip
+    @visit.referrer_group = ReferrerNormalizer.group_for(@visit.referrer)
     sanitize
 
     if @visit.save

--- a/app/models/incoming_visit.rb
+++ b/app/models/incoming_visit.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Represents a Visit arriving over HTTP. Holds the raw request inputs
+# and knows how to turn them into a Visit ready for persistence:
+# applies the request's remote IP, derives referrer_group via
+# ReferrerNormalizer, and sanitizes the free-text fields. Returns an
+# unsaved Visit so the caller controls persistence and response.
+class IncomingVisit
+  def initialize(params:, remote_ip:)
+    @params = params
+    @remote_ip = remote_ip
+  end
+
+  def build
+    Visit.new(@params).tap do |visit|
+      visit.remote_ip = @remote_ip
+      visit.referrer_group = ReferrerNormalizer.group_for(visit.referrer)
+      sanitize(visit)
+    end
+  end
+
+  private
+
+  # https://stackoverflow.com/questions/3985989/using-sanitize-within-a-rails-controller
+  def sanitize(visit)
+    visit.user_agent = ActionController::Base.helpers.sanitize(visit.user_agent)
+    visit.url = ActionController::Base.helpers.sanitize(visit.url)
+  end
+end

--- a/app/models/referrer_normalizer.rb
+++ b/app/models/referrer_normalizer.rb
@@ -5,142 +5,15 @@
 # the write path and the backfill task. See
 # scratch/referrer-research/CONSOLIDATION-PLAN.md for the rationale.
 #
-# Rule order is load-bearing: specific google.com subdomains must
-# precede the generic Google rule.
-class ReferrerNormalizer # rubocop:disable Metrics/ClassLength
-  OWN_DOMAIN = "danielabaron.me"
-
-  # rubocop:disable Layout/LineLength
-  RULES = [
-    # --- Email / messaging (specific google.com subdomains must come BEFORE the generic Google rule) ---
-    { match: ->(h) { ["mail.google.com", "googleandroidgm"].include?(h) }, group: "Gmail" },
-    { match: ->(h) { h == "keep.google.com" }, group: "Google Keep" },
-
-    # --- AI assistants ---
-    { match: ->(h) { h.include?("gemini.google.com") }, group: "Gemini" },
-    { match: ->(h) { h.include?("perplexity.ai") }, group: "Perplexity" },
-    { match: ->(h) { ["chatgpt.com", "chat.openai.com"].include?(h) }, group: "ChatGPT" },
-    { match: ->(h) { h == "claude.ai" }, group: "Claude" },
-    { match: ->(h) { h.include?("copilot.microsoft.com") }, group: "Microsoft Copilot" },
-
-    # --- Search engines ---
-    { match: ->(h) { h.match?(/(^|\.)google\./) }, group: "Google" },
-    { match: ->(h) { h == "googlequicksearchbox" }, group: "Google" },
-    { match: ->(h) { h.include?("duckduckgo.com") }, group: "DuckDuckGo" },
-    { match: ->(h) { h.include?("bing.com") }, group: "Bing" },
-    { match: ->(h) { h == "yandex.ru" || h == "ya.ru" || h.match?(/(^|\.)yandex\./) }, group: "Yandex" },
-    { match: ->(h) { ["search.brave.com", "brave.com"].include?(h) }, group: "Brave Search" },
-    { match: ->(h) { h.include?("ecosia.org") }, group: "Ecosia" },
-    { match: ->(h) { h.include?("kagi.com") }, group: "Kagi" },
-    { match: ->(h) { h.include?("startpage.com") }, group: "Startpage" },
-    { match: ->(h) { h.include?("qwant.com") }, group: "Qwant" },
-    { match: ->(h) { h.include?("search.yahoo.com") || h.end_with?(".yahoo.com") }, group: "Yahoo" },
-    { match: ->(h) { h.include?("presearch.com") }, group: "Presearch" },
-    { match: ->(h) { h == "you.com" }, group: "You.com" },
-    { match: ->(h) { h.include?("baidu.com") }, group: "Baidu" },
-    { match: ->(h) { h == "search.lilo.org" }, group: "Lilo" },
-
-    # --- Social / discussion ---
-    { match: ->(h) { h == "hn.algolia.com" }, group: "Hacker News" },
-    { match: ->(h) { h.include?("reddit.com") || h == "redditfrontpage" }, group: "Reddit" },
-    { match: ->(h) { h.include?("ycombinator.com") }, group: "Hacker News" },
-    { match: ->(h) { h == "t.co" || h.include?("twitter.com") || h == "x.com" }, group: "Twitter / X" },
-    { match: ->(h) { h.include?("linkedin.com") || h == "lnkd.in" || h == "linkedinandroid" }, group: "LinkedIn" },
-    { match: ->(h) { h.include?("facebook.com") || h == "l.facebook.com" || h == "fb.me" }, group: "Facebook" },
-    { match: ->(h) { h.include?("mastodon") || h.include?("joinmastodon") }, group: "Mastodon" },
-    { match: ->(h) { h.include?("bsky.app") || h.include?("bluesky") }, group: "Bluesky" },
-    { match: ->(h) { h == "eksisozluk.com" || h.include?("eksisozluk") }, group: "Eksi Sozluk (TR forum)" },
-
-    # --- Messaging / chat ---
-    { match: ->(h) { h == "statics.teams.cdn.office.net" || h.include?("teams.microsoft") }, group: "MS Teams" },
-    { match: ->(h) { h == "slack" || h.include?("slack.com") }, group: "Slack" },
-
-    # --- Ruby/JS dev newsletters & aggregators ---
-    { match: ->(h) { h == "rubyflow.com" }, group: "RubyFlow" },
-    { match: ->(h) { h == "rubyweekly.com" }, group: "Ruby Weekly" },
-    { match: ->(h) { h == "rubyland.news" }, group: "Rubyland News" },
-    { match: ->(h) { h == "javascriptweekly.com" }, group: "JavaScript Weekly" },
-    { match: ->(h) { h == "frontendfoc.us" }, group: "Frontend Focus" },
-    { match: ->(h) { ["hotwireweekly.com", "www.hotwireweekly.com"].include?(h) }, group: "Hotwire Weekly" },
-    { match: ->(h) { h == "changelog.com" }, group: "Changelog" },
-    { match: ->(h) { h == "ruby.libhunt.com" }, group: "Libhunt Ruby" },
-    { match: ->(h) { h == "rubyonrails.ba" }, group: "Rails BA" },
-    { match: ->(h) { h.include?("shortruby.com") || h == "newsletter.shortruby.com" }, group: "Short Ruby" },
-    { match: ->(h) { h.include?("tldrnewsletter.com") || h.include?("tldr.tech") }, group: "TLDR Newsletter" },
-    { match: ->(h) { h == "news.humancoders.com" }, group: "Human Coders (FR)" },
-    { match: ->(h) { h == "dou.ua" }, group: "DOU (UA)" },
-    { match: ->(h) { h == "curso.dev" }, group: "curso.dev" },
-    { match: ->(h) { h == "dev.to" }, group: "dev.to" },
-    { match: ->(h) { h == "maintainable.fm" }, group: "Maintainable (podcast)" },
-    { match: ->(h) { h == "planetruby.org" }, group: "Planet Ruby" },
-    { match: ->(h) { h == "hacklines.com" }, group: "Hacklines" },
-
-    # --- Read-later / curation ---
-    { match: ->(h) { h.include?("feedly.com") }, group: "Feedly" },
-    { match: ->(h) { h.include?("inoreader.com") }, group: "Inoreader" },
-    { match: ->(h) { h == "refind.com" }, group: "Refind" },
-    { match: ->(h) { h.include?("readwise.io") }, group: "Readwise" },
-    { match: ->(h) { h.include?("raindrop.io") }, group: "Raindrop" },
-    { match: ->(h) { ["api.daily.dev", "daily.dev", "app.daily.dev"].include?(h) }, group: "daily.dev" },
-    { match: ->(h) { h == "linktr.ee" }, group: "Linktree" },
-    { match: ->(h) { h == "pinboard.in" }, group: "Pinboard" },
-    { match: ->(h) { h == "instapaper.com" }, group: "Instapaper" },
-    { match: ->(h) { h == "getpocket.com" }, group: "Pocket" },
-    { match: ->(h) { h == "feeder.co" }, group: "Feeder" },
-
-    # --- Blog mentions / Substack / Medium ---
-    { match: ->(h) { h == "storiesfromtheherd.com" }, group: "Stories from the Herd (Medium)" },
-    { match: ->(h) { ["www.writesoftwarewell.com", "writesoftwarewell.com"].include?(h) }, group: "Write Software Well" },
-    { match: ->(h) { h == "garrettdimon.com" }, group: "garrettdimon.com" },
-    { match: ->(h) { h == "view.hashicorp.com" }, group: "HashiCorp (newsletter)" },
-    { match: ->(h) { h.include?("substack.com") }, group: "Substack (other)" },
-    { match: ->(h) { h == "medium.com" || h.end_with?(".medium.com") || h == "scribe.rip" }, group: "Medium" },
-    { match: ->(h) { h.include?("buttondown.com") || h.include?("buttondown.email") }, group: "Buttondown" },
-    { match: ->(h) { h == "andyatkinson.com" }, group: "andyatkinson.com" },
-
-    # --- GitHub ---
-    { match: ->(h) { ["github.com", "gist.github.com"].include?(h) }, group: "GitHub" },
-
-    # --- Self-referrers ---
-    { match: ->(h) { h == OWN_DOMAIN || h.end_with?(".#{OWN_DOMAIN}") }, group: "self" },
-
-    # --- Browser internal junk ---
-    { match: ->(h) { h == "newtab" || h.start_with?("about") }, group: "Browser new tab" }
-  ].freeze
-  # rubocop:enable Layout/LineLength
-
+# Rule order in Classifier is load-bearing: specific google.com subdomains
+# must precede the generic Google rule.
+class ReferrerNormalizer
   def self.group_for(raw_referrer)
     return nil if raw_referrer.blank?
 
-    host = extract_host(raw_referrer)
+    host = HostExtractor.host_for(raw_referrer)
     return nil if host.blank?
 
-    rule = RULES.find { |r| r[:match].call(host) }
-    rule ? rule[:group] : host
-  end
-
-  def self.extract_host(referrer) # rubocop:disable Metrics/CyclomaticComplexity
-    return nil if referrer.blank?
-
-    if referrer.start_with?("android-app://")
-      pkg = referrer.sub("android-app://", "").split("/").first.to_s
-      return case pkg
-             when /com\.google\.android\.gm/ then "googleandroidgm"
-             when /com\.google\.android\.googlequicksearchbox/ then "googlequicksearchbox"
-             when /com\.linkedin\.android/ then "linkedinandroid"
-             when /com\.reddit/ then "redditfrontpage"
-             when /com\.slack/ then "slack"
-             else pkg
-             end
-    end
-
-    return "newtab" if referrer.start_with?("about:")
-
-    uri = URI.parse(referrer.strip)
-    host = uri.host.to_s.downcase
-    %w[www. m. l. out. old. new.].each { |prefix| host = host.delete_prefix(prefix) }
-    host
-  rescue URI::InvalidURIError
-    nil
+    Classifier.group_for(host)
   end
 end

--- a/app/models/referrer_normalizer.rb
+++ b/app/models/referrer_normalizer.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+# Classifies a raw referrer string into a consolidated group label
+# (e.g. https://www.google.de/ -> "Google"). Source of truth for both
+# the write path and the backfill task. See
+# scratch/referrer-research/CONSOLIDATION-PLAN.md for the rationale.
+#
+# Rule order is load-bearing: specific google.com subdomains must
+# precede the generic Google rule.
+class ReferrerNormalizer # rubocop:disable Metrics/ClassLength
+  OWN_DOMAIN = "danielabaron.me"
+
+  # rubocop:disable Layout/LineLength
+  RULES = [
+    # --- Email / messaging (specific google.com subdomains must come BEFORE the generic Google rule) ---
+    { match: ->(h) { ["mail.google.com", "googleandroidgm"].include?(h) }, group: "Gmail" },
+    { match: ->(h) { h == "keep.google.com" }, group: "Google Keep" },
+
+    # --- AI assistants ---
+    { match: ->(h) { h.include?("gemini.google.com") }, group: "Gemini" },
+    { match: ->(h) { h.include?("perplexity.ai") }, group: "Perplexity" },
+    { match: ->(h) { ["chatgpt.com", "chat.openai.com"].include?(h) }, group: "ChatGPT" },
+    { match: ->(h) { h == "claude.ai" }, group: "Claude" },
+    { match: ->(h) { h.include?("copilot.microsoft.com") }, group: "Microsoft Copilot" },
+
+    # --- Search engines ---
+    { match: ->(h) { h.match?(/(^|\.)google\./) }, group: "Google" },
+    { match: ->(h) { h == "googlequicksearchbox" }, group: "Google" },
+    { match: ->(h) { h.include?("duckduckgo.com") }, group: "DuckDuckGo" },
+    { match: ->(h) { h.include?("bing.com") }, group: "Bing" },
+    { match: ->(h) { h == "yandex.ru" || h == "ya.ru" || h.match?(/(^|\.)yandex\./) }, group: "Yandex" },
+    { match: ->(h) { ["search.brave.com", "brave.com"].include?(h) }, group: "Brave Search" },
+    { match: ->(h) { h.include?("ecosia.org") }, group: "Ecosia" },
+    { match: ->(h) { h.include?("kagi.com") }, group: "Kagi" },
+    { match: ->(h) { h.include?("startpage.com") }, group: "Startpage" },
+    { match: ->(h) { h.include?("qwant.com") }, group: "Qwant" },
+    { match: ->(h) { h.include?("search.yahoo.com") || h.end_with?(".yahoo.com") }, group: "Yahoo" },
+    { match: ->(h) { h.include?("presearch.com") }, group: "Presearch" },
+    { match: ->(h) { h == "you.com" }, group: "You.com" },
+    { match: ->(h) { h.include?("baidu.com") }, group: "Baidu" },
+    { match: ->(h) { h == "search.lilo.org" }, group: "Lilo" },
+
+    # --- Social / discussion ---
+    { match: ->(h) { h == "hn.algolia.com" }, group: "Hacker News" },
+    { match: ->(h) { h.include?("reddit.com") || h == "redditfrontpage" }, group: "Reddit" },
+    { match: ->(h) { h.include?("ycombinator.com") }, group: "Hacker News" },
+    { match: ->(h) { h == "t.co" || h.include?("twitter.com") || h == "x.com" }, group: "Twitter / X" },
+    { match: ->(h) { h.include?("linkedin.com") || h == "lnkd.in" || h == "linkedinandroid" }, group: "LinkedIn" },
+    { match: ->(h) { h.include?("facebook.com") || h == "l.facebook.com" || h == "fb.me" }, group: "Facebook" },
+    { match: ->(h) { h.include?("mastodon") || h.include?("joinmastodon") }, group: "Mastodon" },
+    { match: ->(h) { h.include?("bsky.app") || h.include?("bluesky") }, group: "Bluesky" },
+    { match: ->(h) { h == "eksisozluk.com" || h.include?("eksisozluk") }, group: "Eksi Sozluk (TR forum)" },
+
+    # --- Messaging / chat ---
+    { match: ->(h) { h == "statics.teams.cdn.office.net" || h.include?("teams.microsoft") }, group: "MS Teams" },
+    { match: ->(h) { h == "slack" || h.include?("slack.com") }, group: "Slack" },
+
+    # --- Ruby/JS dev newsletters & aggregators ---
+    { match: ->(h) { h == "rubyflow.com" }, group: "RubyFlow" },
+    { match: ->(h) { h == "rubyweekly.com" }, group: "Ruby Weekly" },
+    { match: ->(h) { h == "rubyland.news" }, group: "Rubyland News" },
+    { match: ->(h) { h == "javascriptweekly.com" }, group: "JavaScript Weekly" },
+    { match: ->(h) { h == "frontendfoc.us" }, group: "Frontend Focus" },
+    { match: ->(h) { ["hotwireweekly.com", "www.hotwireweekly.com"].include?(h) }, group: "Hotwire Weekly" },
+    { match: ->(h) { h == "changelog.com" }, group: "Changelog" },
+    { match: ->(h) { h == "ruby.libhunt.com" }, group: "Libhunt Ruby" },
+    { match: ->(h) { h == "rubyonrails.ba" }, group: "Rails BA" },
+    { match: ->(h) { h.include?("shortruby.com") || h == "newsletter.shortruby.com" }, group: "Short Ruby" },
+    { match: ->(h) { h.include?("tldrnewsletter.com") || h.include?("tldr.tech") }, group: "TLDR Newsletter" },
+    { match: ->(h) { h == "news.humancoders.com" }, group: "Human Coders (FR)" },
+    { match: ->(h) { h == "dou.ua" }, group: "DOU (UA)" },
+    { match: ->(h) { h == "curso.dev" }, group: "curso.dev" },
+    { match: ->(h) { h == "dev.to" }, group: "dev.to" },
+    { match: ->(h) { h == "maintainable.fm" }, group: "Maintainable (podcast)" },
+    { match: ->(h) { h == "planetruby.org" }, group: "Planet Ruby" },
+    { match: ->(h) { h == "hacklines.com" }, group: "Hacklines" },
+
+    # --- Read-later / curation ---
+    { match: ->(h) { h.include?("feedly.com") }, group: "Feedly" },
+    { match: ->(h) { h.include?("inoreader.com") }, group: "Inoreader" },
+    { match: ->(h) { h == "refind.com" }, group: "Refind" },
+    { match: ->(h) { h.include?("readwise.io") }, group: "Readwise" },
+    { match: ->(h) { h.include?("raindrop.io") }, group: "Raindrop" },
+    { match: ->(h) { ["api.daily.dev", "daily.dev", "app.daily.dev"].include?(h) }, group: "daily.dev" },
+    { match: ->(h) { h == "linktr.ee" }, group: "Linktree" },
+    { match: ->(h) { h == "pinboard.in" }, group: "Pinboard" },
+    { match: ->(h) { h == "instapaper.com" }, group: "Instapaper" },
+    { match: ->(h) { h == "getpocket.com" }, group: "Pocket" },
+    { match: ->(h) { h == "feeder.co" }, group: "Feeder" },
+
+    # --- Blog mentions / Substack / Medium ---
+    { match: ->(h) { h == "storiesfromtheherd.com" }, group: "Stories from the Herd (Medium)" },
+    { match: ->(h) { ["www.writesoftwarewell.com", "writesoftwarewell.com"].include?(h) }, group: "Write Software Well" },
+    { match: ->(h) { h == "garrettdimon.com" }, group: "garrettdimon.com" },
+    { match: ->(h) { h == "view.hashicorp.com" }, group: "HashiCorp (newsletter)" },
+    { match: ->(h) { h.include?("substack.com") }, group: "Substack (other)" },
+    { match: ->(h) { h == "medium.com" || h.end_with?(".medium.com") || h == "scribe.rip" }, group: "Medium" },
+    { match: ->(h) { h.include?("buttondown.com") || h.include?("buttondown.email") }, group: "Buttondown" },
+    { match: ->(h) { h == "andyatkinson.com" }, group: "andyatkinson.com" },
+
+    # --- GitHub ---
+    { match: ->(h) { ["github.com", "gist.github.com"].include?(h) }, group: "GitHub" },
+
+    # --- Self-referrers ---
+    { match: ->(h) { h == OWN_DOMAIN || h.end_with?(".#{OWN_DOMAIN}") }, group: "self" },
+
+    # --- Browser internal junk ---
+    { match: ->(h) { h == "newtab" || h.start_with?("about") }, group: "Browser new tab" }
+  ].freeze
+  # rubocop:enable Layout/LineLength
+
+  def self.group_for(raw_referrer)
+    return nil if raw_referrer.blank?
+
+    host = extract_host(raw_referrer)
+    return nil if host.blank?
+
+    rule = RULES.find { |r| r[:match].call(host) }
+    rule ? rule[:group] : host
+  end
+
+  def self.extract_host(referrer) # rubocop:disable Metrics/CyclomaticComplexity
+    return nil if referrer.blank?
+
+    if referrer.start_with?("android-app://")
+      pkg = referrer.sub("android-app://", "").split("/").first.to_s
+      return case pkg
+             when /com\.google\.android\.gm/ then "googleandroidgm"
+             when /com\.google\.android\.googlequicksearchbox/ then "googlequicksearchbox"
+             when /com\.linkedin\.android/ then "linkedinandroid"
+             when /com\.reddit/ then "redditfrontpage"
+             when /com\.slack/ then "slack"
+             else pkg
+             end
+    end
+
+    return "newtab" if referrer.start_with?("about:")
+
+    uri = URI.parse(referrer.strip)
+    host = uri.host.to_s.downcase
+    %w[www. m. l. out. old. new.].each { |prefix| host = host.delete_prefix(prefix) }
+    host
+  rescue URI::InvalidURIError
+    nil
+  end
+end

--- a/app/models/referrer_normalizer.rb
+++ b/app/models/referrer_normalizer.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
-# Classifies a raw referrer string into a consolidated group label
-# (e.g. https://www.google.de/ -> "Google"). Source of truth for both
-# the write path and the backfill task. See
-# scratch/referrer-research/CONSOLIDATION-PLAN.md for the rationale.
-#
-# Rule order in Classifier is load-bearing: specific google.com subdomains
-# must precede the generic Google rule.
+# Coordinates the two-step pipeline that turns a raw referrer string into a
+# dashboard-ready group label. HostExtractor handles the messy input formats;
+# Classifier maps the resulting host token to a human-readable source name.
+# Keeping the steps separate lets each be tested in isolation.
 class ReferrerNormalizer
   def self.group_for(raw_referrer)
     return nil if raw_referrer.blank?

--- a/app/models/referrer_normalizer/classifier.rb
+++ b/app/models/referrer_normalizer/classifier.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+# Maps a normalized host token to a human-readable group label for the
+# analytics dashboard. Raw hosts like "t.co" or "mail.google.com" are noise;
+# grouping them into "Twitter / X" or "Gmail" makes the referrer breakdown
+# meaningful to the site owner.
+#
+# Rule order is load-bearing: specific google.com subdomains (Gmail, Keep,
+# Gemini) must appear before the generic Google catch-all regex.
 class ReferrerNormalizer
   class Classifier
     OWN_DOMAIN = "danielabaron.me"

--- a/app/models/referrer_normalizer/classifier.rb
+++ b/app/models/referrer_normalizer/classifier.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+class ReferrerNormalizer
+  class Classifier
+    OWN_DOMAIN = "danielabaron.me"
+
+    RULES = [
+      # --- Email / messaging (specific google.com subdomains must come BEFORE the generic Google rule) ---
+      { match: ->(h) { ["mail.google.com", "googleandroidgm"].include?(h) }, group: "Gmail" },
+      { match: ->(h) { h == "keep.google.com" }, group: "Google Keep" },
+
+      # --- AI assistants ---
+      { match: ->(h) { h.include?("gemini.google.com") }, group: "Gemini" },
+      { match: ->(h) { h.include?("perplexity.ai") }, group: "Perplexity" },
+      { match: ->(h) { ["chatgpt.com", "chat.openai.com"].include?(h) }, group: "ChatGPT" },
+      { match: ->(h) { h == "claude.ai" }, group: "Claude" },
+      { match: ->(h) { h.include?("copilot.microsoft.com") }, group: "Microsoft Copilot" },
+
+      # --- Search engines ---
+      { match: ->(h) { h.match?(/(^|\.)google\./) }, group: "Google" },
+      { match: ->(h) { h == "googlequicksearchbox" }, group: "Google" },
+      { match: ->(h) { h.include?("duckduckgo.com") }, group: "DuckDuckGo" },
+      { match: ->(h) { h.include?("bing.com") }, group: "Bing" },
+      { match: ->(h) { h == "yandex.ru" || h == "ya.ru" || h.match?(/(^|\.)yandex\./) }, group: "Yandex" },
+      { match: ->(h) { ["search.brave.com", "brave.com"].include?(h) }, group: "Brave Search" },
+      { match: ->(h) { h.include?("ecosia.org") }, group: "Ecosia" },
+      { match: ->(h) { h.include?("kagi.com") }, group: "Kagi" },
+      { match: ->(h) { h.include?("startpage.com") }, group: "Startpage" },
+      { match: ->(h) { h.include?("qwant.com") }, group: "Qwant" },
+      { match: ->(h) { h.include?("search.yahoo.com") || h.end_with?(".yahoo.com") }, group: "Yahoo" },
+      { match: ->(h) { h.include?("presearch.com") }, group: "Presearch" },
+      { match: ->(h) { h == "you.com" }, group: "You.com" },
+      { match: ->(h) { h.include?("baidu.com") }, group: "Baidu" },
+      { match: ->(h) { h == "search.lilo.org" }, group: "Lilo" },
+
+      # --- Social / discussion ---
+      { match: ->(h) { h == "hn.algolia.com" }, group: "Hacker News" },
+      { match: ->(h) { h.include?("reddit.com") || h == "redditfrontpage" }, group: "Reddit" },
+      { match: ->(h) { h.include?("ycombinator.com") }, group: "Hacker News" },
+      { match: ->(h) { h == "t.co" || h.include?("twitter.com") || h == "x.com" }, group: "Twitter / X" },
+      { match: ->(h) { h.include?("linkedin.com") || h == "lnkd.in" || h == "linkedinandroid" }, group: "LinkedIn" },
+      { match: ->(h) { h.include?("facebook.com") || h == "fb.me" }, group: "Facebook" },
+      { match: ->(h) { h.include?("mastodon") || h.include?("joinmastodon") }, group: "Mastodon" },
+      { match: ->(h) { h.include?("bsky.app") || h.include?("bluesky") }, group: "Bluesky" },
+      { match: ->(h) { h == "eksisozluk.com" || h.include?("eksisozluk") }, group: "Eksi Sozluk (TR forum)" },
+
+      # --- Messaging / chat ---
+      { match: ->(h) { h == "statics.teams.cdn.office.net" || h.include?("teams.microsoft") }, group: "MS Teams" },
+      { match: ->(h) { h == "slack" || h.include?("slack.com") }, group: "Slack" },
+
+      # --- Ruby/JS dev newsletters & aggregators ---
+      { match: ->(h) { h == "rubyflow.com" }, group: "RubyFlow" },
+      { match: ->(h) { h == "rubyweekly.com" }, group: "Ruby Weekly" },
+      { match: ->(h) { h == "rubyland.news" }, group: "Rubyland News" },
+      { match: ->(h) { h == "javascriptweekly.com" }, group: "JavaScript Weekly" },
+      { match: ->(h) { h == "frontendfoc.us" }, group: "Frontend Focus" },
+      { match: ->(h) { ["hotwireweekly.com", "www.hotwireweekly.com"].include?(h) }, group: "Hotwire Weekly" },
+      { match: ->(h) { h == "changelog.com" }, group: "Changelog" },
+      { match: ->(h) { h == "ruby.libhunt.com" }, group: "Libhunt Ruby" },
+      { match: ->(h) { h == "rubyonrails.ba" }, group: "Rails BA" },
+      { match: ->(h) { h.include?("shortruby.com") || h == "newsletter.shortruby.com" }, group: "Short Ruby" },
+      { match: ->(h) { h.include?("tldrnewsletter.com") || h.include?("tldr.tech") }, group: "TLDR Newsletter" },
+      { match: ->(h) { h == "news.humancoders.com" }, group: "Human Coders (FR)" },
+      { match: ->(h) { h == "dou.ua" }, group: "DOU (UA)" },
+      { match: ->(h) { h == "curso.dev" }, group: "curso.dev" },
+      { match: ->(h) { h == "dev.to" }, group: "dev.to" },
+      { match: ->(h) { h == "maintainable.fm" }, group: "Maintainable (podcast)" },
+      { match: ->(h) { h == "planetruby.org" }, group: "Planet Ruby" },
+      { match: ->(h) { h == "hacklines.com" }, group: "Hacklines" },
+
+      # --- Read-later / curation ---
+      { match: ->(h) { h.include?("feedly.com") }, group: "Feedly" },
+      { match: ->(h) { h.include?("inoreader.com") }, group: "Inoreader" },
+      { match: ->(h) { h == "refind.com" }, group: "Refind" },
+      { match: ->(h) { h.include?("readwise.io") }, group: "Readwise" },
+      { match: ->(h) { h.include?("raindrop.io") }, group: "Raindrop" },
+      { match: ->(h) { ["api.daily.dev", "daily.dev", "app.daily.dev"].include?(h) }, group: "daily.dev" },
+      { match: ->(h) { h == "linktr.ee" }, group: "Linktree" },
+      { match: ->(h) { h == "pinboard.in" }, group: "Pinboard" },
+      { match: ->(h) { h == "instapaper.com" }, group: "Instapaper" },
+      { match: ->(h) { h == "getpocket.com" }, group: "Pocket" },
+      { match: ->(h) { h == "feeder.co" }, group: "Feeder" },
+
+      # --- Blog mentions / Substack / Medium ---
+      { match: ->(h) { h == "storiesfromtheherd.com" }, group: "Stories from the Herd (Medium)" },
+      { match: ->(h) { h == "www.writesoftwarewell.com" }, group: "Write Software Well" },
+      { match: ->(h) { h == "writesoftwarewell.com" },     group: "Write Software Well" },
+      { match: ->(h) { h == "garrettdimon.com" }, group: "garrettdimon.com" },
+      { match: ->(h) { h == "view.hashicorp.com" }, group: "HashiCorp (newsletter)" },
+      { match: ->(h) { h.include?("substack.com") }, group: "Substack (other)" },
+      { match: ->(h) { h == "medium.com" || h.end_with?(".medium.com") || h == "scribe.rip" }, group: "Medium" },
+      { match: ->(h) { h.include?("buttondown.com") || h.include?("buttondown.email") }, group: "Buttondown" },
+      { match: ->(h) { h == "andyatkinson.com" }, group: "andyatkinson.com" },
+
+      # --- GitHub ---
+      { match: ->(h) { ["github.com", "gist.github.com"].include?(h) }, group: "GitHub" },
+
+      # --- Self-referrers ---
+      { match: ->(h) { h == OWN_DOMAIN || h.end_with?(".#{OWN_DOMAIN}") }, group: "self" },
+
+      # --- Browser internal junk ---
+      { match: ->(h) { h == "newtab" || h.start_with?("about") }, group: "Browser new tab" }
+    ].freeze
+
+    def self.group_for(host)
+      rule = RULES.find { |r| r[:match].call(host) }
+      rule ? rule[:group] : host
+    end
+  end
+end

--- a/app/models/referrer_normalizer/host_extractor.rb
+++ b/app/models/referrer_normalizer/host_extractor.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# Normalizes a raw referrer into a plain host token so Classifier rules can
+# stay simple and pattern-match against one canonical form. Browsers and apps
+# send referrers in wildly different formats (https:// URLs, android-app://
+# URIs, about: strings) — this class absorbs all of that variability.
+# Common prefixes (www., m., etc.) are stripped here for the same reason.
 class ReferrerNormalizer
   class HostExtractor
     ANDROID_APP_TOKENS = {

--- a/app/models/referrer_normalizer/host_extractor.rb
+++ b/app/models/referrer_normalizer/host_extractor.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class ReferrerNormalizer
+  class HostExtractor
+    ANDROID_APP_TOKENS = {
+      /com\.google\.android\.gm/ => "googleandroidgm",
+      /com\.google\.android\.googlequicksearchbox/ => "googlequicksearchbox",
+      /com\.linkedin\.android/ => "linkedinandroid",
+      /com\.reddit/ => "redditfrontpage",
+      /com\.slack/ => "slack"
+    }.freeze
+
+    STRIPPED_PREFIXES = %w[www. m. l. out. old. new.].freeze
+
+    def self.host_for(referrer)
+      return nil if referrer.blank?
+      return from_android_app(referrer) if referrer.start_with?("android-app://")
+      return "newtab"                   if referrer.start_with?("about:")
+
+      from_uri(referrer)
+    end
+
+    def self.from_android_app(referrer)
+      pkg = referrer.sub("android-app://", "").split("/").first.to_s
+      _, token = ANDROID_APP_TOKENS.find { |pattern, _| pkg.match?(pattern) }
+      token || pkg
+    end
+
+    def self.from_uri(referrer)
+      uri  = URI.parse(referrer.strip)
+      host = uri.host.to_s.downcase
+      STRIPPED_PREFIXES.each { |prefix| host = host.delete_prefix(prefix) }
+      host
+    rescue URI::InvalidURIError
+      nil
+    end
+  end
+end

--- a/http/visit.http
+++ b/http/visit.http
@@ -5,7 +5,8 @@ content-type: application/json
   "visit": {
     "guest_timezone_offset": "400",
     "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.192 Safari/537.36",
-    "url": "https://danielabaron.me/blog/python-interview-question-in-ruby/"
+    "url": "https://danielabaron.me/blog/python-interview-question-in-ruby/",
+    "referrer": "{{referrer}}"
   }
 }
 

--- a/spec/models/incoming_visit_spec.rb
+++ b/spec/models/incoming_visit_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IncomingVisit do
+  describe "#build" do
+    subject(:visit) { described_class.new(params: params, remote_ip: remote_ip).build }
+
+    let(:params) do
+      {
+        guest_timezone_offset: 240,
+        user_agent: "Mozilla/5.0",
+        url: "https://example.com/page",
+        referrer: "https://www.google.de/"
+      }
+    end
+    let(:remote_ip) { "203.0.113.42" }
+
+    it "returns an unsaved Visit" do
+      expect(visit).to be_a(Visit)
+      expect(visit).not_to be_persisted
+    end
+
+    it "assigns the remote IP from the request" do
+      expect(visit.remote_ip).to eq(remote_ip)
+    end
+
+    it "derives referrer_group via ReferrerNormalizer" do
+      expect(visit.referrer_group).to eq("Google")
+    end
+
+    it "leaves referrer_group nil when referrer is blank" do
+      params[:referrer] = ""
+      expect(visit.referrer_group).to be_nil
+    end
+
+    it "sanitizes the user_agent field" do
+      params[:user_agent] = "<script>alert('xss')</script>Mozilla"
+      expect(visit.user_agent).not_to include("<script>")
+    end
+
+    it "sanitizes the url field" do
+      params[:url] = "<script>alert('xss')</script>https://example.com"
+      expect(visit.url).not_to include("<script>")
+    end
+
+    it "passes through visit_params attributes" do
+      expect(visit.guest_timezone_offset).to eq(240)
+    end
+  end
+end

--- a/spec/models/referrer_normalizer/host_extractor_spec.rb
+++ b/spec/models/referrer_normalizer/host_extractor_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ReferrerNormalizer::HostExtractor do
+  describe ".host_for" do
+    it "returns nil for blank input" do
+      expect(described_class.host_for("")).to be_nil
+      expect(described_class.host_for(nil)).to be_nil
+    end
+
+    it "returns nil for an unparseable URI" do
+      expect(described_class.host_for("not a url !!!")).to be_nil
+    end
+
+    context "when referrer uses the android-app:// scheme" do
+      it "maps com.google.android.gm to googleandroidgm" do
+        expect(described_class.host_for("android-app://com.google.android.gm/")).to eq("googleandroidgm")
+      end
+
+      it "maps com.google.android.googlequicksearchbox to googlequicksearchbox" do
+        url = "android-app://com.google.android.googlequicksearchbox/"
+        expect(described_class.host_for(url)).to eq("googlequicksearchbox")
+      end
+
+      it "maps com.linkedin.android to linkedinandroid" do
+        expect(described_class.host_for("android-app://com.linkedin.android/")).to eq("linkedinandroid")
+      end
+
+      it "maps com.reddit.* to redditfrontpage" do
+        expect(described_class.host_for("android-app://com.reddit.frontpage/")).to eq("redditfrontpage")
+      end
+
+      it "maps com.slack.* to slack" do
+        expect(described_class.host_for("android-app://com.slack.android/")).to eq("slack")
+      end
+
+      it "falls back to the bare package name for unknown apps" do
+        expect(described_class.host_for("android-app://com.example.unknown/")).to eq("com.example.unknown")
+      end
+    end
+
+    context "when referrer uses the about: scheme" do
+      it "returns newtab for about:newtab" do
+        expect(described_class.host_for("about:newtab")).to eq("newtab")
+      end
+
+      it "returns newtab for any about: url" do
+        expect(described_class.host_for("about:blank")).to eq("newtab")
+      end
+    end
+
+    context "when referrer is a normal URI" do
+      it "extracts the host" do
+        expect(described_class.host_for("https://github.com/foo/bar")).to eq("github.com")
+      end
+
+      it "strips www." do
+        expect(described_class.host_for("https://www.google.com/")).to eq("google.com")
+      end
+
+      it "strips m." do
+        expect(described_class.host_for("https://m.facebook.com/")).to eq("facebook.com")
+      end
+
+      it "strips l." do
+        expect(described_class.host_for("https://l.facebook.com/")).to eq("facebook.com")
+      end
+
+      it "strips out." do
+        expect(described_class.host_for("https://out.reddit.com/")).to eq("reddit.com")
+      end
+
+      it "strips old." do
+        expect(described_class.host_for("https://old.reddit.com/")).to eq("reddit.com")
+      end
+
+      it "strips new." do
+        expect(described_class.host_for("https://new.example.com/")).to eq("example.com")
+      end
+
+      it "lowercases the host" do
+        expect(described_class.host_for("https://GitHub.COM/foo")).to eq("github.com")
+      end
+    end
+  end
+end

--- a/spec/models/referrer_normalizer_spec.rb
+++ b/spec/models/referrer_normalizer_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ReferrerNormalizer do
+  describe ".group_for" do
+    it "returns nil for blank or nil input" do
+      expect(described_class.group_for("")).to be_nil
+      expect(described_class.group_for(nil)).to be_nil
+    end
+
+    it "returns nil for unparseable URIs" do
+      expect(described_class.group_for("not a url at all !!!")).to be_nil
+    end
+
+    {
+      # --- consolidation across Google country domains ---
+      "https://www.google.com/search?q=ruby" => "Google",
+      "https://www.google.de/" => "Google",
+      "https://www.google.ca/" => "Google",
+      # --- specific overrides win over the generic Google rule (rule order matters) ---
+      "https://mail.google.com/" => "Gmail",
+      "https://gemini.google.com/" => "Gemini",
+      "https://keep.google.com/" => "Google Keep",
+      # --- subdomain stripping + reddit consolidation ---
+      "https://www.reddit.com/r/rails/" => "Reddit",
+      "https://old.reddit.com/" => "Reddit",
+      "https://out.reddit.com/" => "Reddit",
+      # --- android-app:// token handling ---
+      "android-app://com.reddit.frontpage/" => "Reddit",
+      "android-app://com.linkedin.android/" => "LinkedIn",
+      "android-app://com.google.android.gm/" => "Gmail",
+      # --- one example from each curated category in classify.rb ---
+      "https://duckduckgo.com/" => "DuckDuckGo",
+      "https://www.perplexity.ai/" => "Perplexity",
+      "https://news.ycombinator.com/" => "Hacker News",
+      "https://t.co/abc" => "Twitter / X",
+      "https://lnkd.in/xyz" => "LinkedIn",
+      "https://rubyflow.com/" => "RubyFlow",
+      "https://feedly.com/" => "Feedly",
+      "https://github.com/foo/bar" => "GitHub",
+      "https://storiesfromtheherd.com/post" => "Stories from the Herd (Medium)",
+      # --- fallback to bare host when no rule matches ---
+      "https://nelson.cloud/some-post" => "nelson.cloud",
+      # --- self-referrer sentinel ---
+      "https://danielabaron.me/blog/foo" => "self",
+      "https://www.danielabaron.me/" => "self",
+      # --- browser-internal junk ---
+      "about:newtab" => "Browser new tab"
+    }.each do |raw, expected|
+      it "classifies #{raw.inspect} as #{expected.inspect}" do
+        expect(described_class.group_for(raw)).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/requests/visits_spec.rb
+++ b/spec/requests/visits_spec.rb
@@ -173,6 +173,48 @@ RSpec.describe "Visits" do
         get "/visits.json"
         expect(response).to have_http_status(:unauthorized)
       end
+
+      it "populates referrer_group from the raw referrer" do
+        headers = { Accept: "application/json", "Content-Type": "application/json" }
+        params = {
+          guest_timezone_offset: 0,
+          user_agent: Faker::Internet.user_agent,
+          url: "https://example.com/p",
+          referrer: "https://www.google.de/"
+        }
+
+        post "/visits", params: params.to_json, headers: headers
+
+        expect(Visit.last.referrer_group).to eq("Google")
+      end
+
+      it "leaves referrer_group NULL when referrer is blank" do
+        headers = { Accept: "application/json", "Content-Type": "application/json" }
+        params = {
+          guest_timezone_offset: 0,
+          user_agent: Faker::Internet.user_agent,
+          url: "https://example.com/p",
+          referrer: ""
+        }
+
+        post "/visits", params: params.to_json, headers: headers
+
+        expect(Visit.last.referrer_group).to be_nil
+      end
+
+      it "stores 'self' for own-domain referrers" do
+        headers = { Accept: "application/json", "Content-Type": "application/json" }
+        params = {
+          guest_timezone_offset: 0,
+          user_agent: Faker::Internet.user_agent,
+          url: "https://example.com/p",
+          referrer: "https://danielabaron.me/blog/foo"
+        }
+
+        post "/visits", params: params.to_json, headers: headers
+
+        expect(Visit.last.referrer_group).to eq("self")
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- Adds `ReferrerNormalizer`, a pure PORO that classifies a raw referrer URL into a consolidated group label (e.g. `https://www.google.de/` → `"Google"`, `https://danielabaron.me/...` → `"self"`). Rules ported from `scratch/referrer-research/classify.rb`; `category:` dropped since we have a single column today.
- Wires `VisitsController#create` to populate `referrer_group` on every new visit via `ReferrerNormalizer.group_for(@visit.referrer)`. Old rows stay `NULL` until the backfill in PR 3.
- This is the first PR in the consolidation sequence where new behavior actually starts running, deliberately ahead of the backfill so any rule bugs surface on a handful of new rows rather than baked into a bulk run.

Detailed plan: [`scratch/referrer-consolidation/PR2-normalizer-and-write-path.md`](https://github.com/danielabar/hello-visitor/blob/main/scratch/referrer-consolidation/PR2-normalizer-and-write-path.md). Part 2 of 4 in #244.

Closes #246

## Test plan

- [x] `bin/rspec spec/models/referrer_normalizer_spec.rb` — 27 examples (blank/nil/unparseable + 24-entry classification matrix covering Google country domains, Gmail/Keep/Gemini overrides, Reddit subdomain stripping, android-app:// tokens, one example per curated category, fallback to bare host, self sentinel, browser-internal).
- [x] `bin/rspec spec/requests/visits_spec.rb` — 3 new POST examples: Google referrer → `"Google"`, blank → `nil`, self → `"self"`.
- [x] `bin/ci` green (brakeman, rubocop, rspec 119, cucumber 12).
- [ ] After deploy, spot-check on prod: `Visit.order(created_at: :desc).limit(20).pluck(:referrer, :referrer_group)` — classifications match expectations; blanks stay nil; rows with `referrer.present? && referrer_group.nil?` are candidates for a follow-up rule.
- [ ] No regression in tracking-endpoint error rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)